### PR TITLE
Add sidebar to Writers route & fix redirect(Bounties #72 & #76)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def index
+    @profile = Profile.new(current_user, view_context)
     @users = User.all.order("longest_streak DESC")
       .paginate(page: params[:page], per_page: 50)
   end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,11 @@
-%section.flex-center--column.writers-section
+= render 'layouts/side_bar'
+
+
+.col-sm-3.col-sm-offset-3
+  = link_to "&#10094; back to my profile".html_safe, profile_path, class: "back"
+
+.col-sm-9.col-sm-offset-3.stats
   %h1.heading Writers
-  = link_to "back to my profile", user_path(current_user), class: "link__small"
   %table.writers-table
     %tr
       %th

--- a/app/views/users/welcome.html.haml
+++ b/app/views/users/welcome.html.haml
@@ -19,4 +19,4 @@
     %li.welcome-list__item
       Your posts are private by default, but you may choose to publish them to the Verba community. Share your work and get feedback.
 
-  = link_to "Let's get started!", root_path, class: "button get-started"
+  = link_to "Let's get started!", write_path, class: "button get-started"


### PR DESCRIPTION
Double fix! :smile: 

Renders usual sidebar on Writers route and moves the "back to my profile" link to keep consistent styling with the Stats route. Per [https://assembly.com/verba/bounties/72](https://assembly.com/verba/bounties/72).  

Redirects to `write` path instead of `root` from Welcome page. Per [https://assembly.com/verba/bounties/76](https://assembly.com/verba/bounties/76).
